### PR TITLE
Allow drive bay 0 to blink

### DIFF
--- a/megablink
+++ b/megablink
@@ -50,11 +50,11 @@ foreach my $drive (@drives) {
 	if ( $drive =~ /^\d+$/ ) {
 		$megaraid_id = $drive;
 	} else {
-		$megaraid_id = $map{$drive} or croak "no mapping for $drive";
+		$megaraid_id = $map{$drive}
 	}
+	croak "no mapping for $drive" unless defined $megaraid_id;
 	print "blinking drive $megaraid_id ($drive), ";
-	my $gonogo = "-start";
-	$gonogo = "stop" if $unblink;
+	my $gonogo = $unblink ? "stop" : "-start";
 	my $cmd = "megacli -PdLocate $gonogo -physdrv[0:$megaraid_id] -a0";
 	print "running $cmd\n";
 	system($cmd);


### PR DESCRIPTION
Because Perl evaluates 0 as false, the blink script was croaking on drive bay 0.