### PR TITLE
Use either SAS or WWN id for match, and include Enc.ID

### DIFF
--- a/megablink
+++ b/megablink
@@ -55,7 +55,7 @@ foreach my $drive (@drives) {
 	croak "no mapping for $drive" unless defined $megaraid_id;
 	print "blinking drive $megaraid_id ($drive), ";
 	my $gonogo = $unblink ? "stop" : "-start";
-	my $cmd = "megacli -PdLocate $gonogo -physdrv[0:$megaraid_id] -a0";
+	my $cmd = "megacli -PdLocate $gonogo -physdrv[$megaraid_id] -a0";
 	print "running $cmd\n";
 	system($cmd);
 }

--- a/megamap
+++ b/megamap
@@ -18,7 +18,7 @@ croak "megacli requires root" if $username ne 'root';
 my $megacli;
 
 unless ($debug) {
-	$megacli = `megacli -pdlist -a0 | egrep 'Slot|^SAS'`;
+	$megacli = `megacli -pdlist -a0 | egrep '^Enclosure Device|^Slot|^SAS|^WWN'`;
 } else {
 	print "# MEGAMAP_DEBUG=$debug\n";
 	$megacli = `cat /tmp/megacli.out`;
@@ -31,14 +31,19 @@ if ( scalar(@megalines) == 0 ) {
 	exit 2;
 }
 
+my $encid;
 my $slot;
 my %slot_map;
 foreach my $line (@megalines) {
+	if ( $line =~ /^Enclosure[ ]Device[ ]ID/x ) {
+		$line =~ s/.* //;
+		$encid = $line;
+	}
 	if ( $line =~ /^Slot[ ]Number/x ) {
 		$line =~ s/.* //;
-		$slot = $line;
+		$slot = $encid.":".$line;
 	}
-	if ( $line =~ /^SAS[ ]Address\(0\)/x ) {
+	if ( $line =~ /^WWN/x ) {
 		$line =~ s/.* //;
 		$slot_map{$slot} = { megacli_sas => $line };
 		my $linux  = $line;
@@ -74,11 +79,49 @@ foreach my $line (@megalines) {
 		$ls_out =~ s{[./]}{}g;
 		$slot_map{$slot}->{dev} = $ls_out;
 	}
+	if ( $line =~ /^SAS[ ]Address\(0\)/x ) {
+		if ( ! $slot_map{$slot}->{linux} ) {
+			$line =~ s/.* //;
+			$slot_map{$slot} = { megacli_sas => $line };
+			my $linux  = $line;
+			my $linux2 = $line;
+			my $end    = hex substr( $linux, 0 - $END_WINDOW );
+			$end--;
+			$end = sprintf "%07x", $end;
+			substr( $linux, 0 - $END_WINDOW ) = $end;
+			substr( $linux2, -1 ) = '.';
+			$linux .= '|' . $linux2;
+
+			my $ls_out;
+			unless ($debug) {
+				$ls_out = `ls -l /dev/disk/by-id | egrep '($linux)' | grep -v part`;
+			} else {
+				$ls_out = `egrep '($linux)' /tmp/ls.out`;
+			}
+			chomp($ls_out);
+			## print "$linux -> $ls_out\n";
+
+			if ( !length $ls_out ) {
+				$slot_map{$slot}->{dev} = q{?};
+				next;
+			}
+
+			my $linux_wwn = 'unk';
+			if ( $ls_out =~ /wwn-(0x[\da-f]+)[ ]/x ) {
+				$linux_wwn = $1 || 'bug';
+			}
+			$slot_map{$slot}->{linux} = $linux_wwn;
+
+			$ls_out =~ s/.* //;
+			$ls_out =~ s{[./]}{}g;
+			$slot_map{$slot}->{dev} = $ls_out;
+		}
+	}
 }
 
 ## print Dumper(\%slot_map);
 
-foreach my $slot ( sort { $a <=> $b } keys %slot_map ) {
+foreach my $slot ( sort { $a cmp $b } keys %slot_map ) {
 	my $dev         = $slot_map{$slot}->{dev};
 	my $linux_drive = $slot_map{$slot}->{linux} || '???';
 	print "$slot\t$dev\t$linux_drive\n";


### PR DESCRIPTION
The existing tooling assumed enclosure id# 0 with blink/unblink, as this may not be the case and scraping the enclosure id is fairly easy, this patch does so within megamap and uses a string containing both the enc.id and disk.id in megablink instead of the hard-coded zero.

Additionally, and this part of the patch is inelegant, I had an issue where the disks with a certain brand in my array did not match via SAS Address, but did (close-)match via WWN, while others would only (close-)match via SAS address.  I extended the code to scrape both and use whichever matched first (WWN comes first in the megacli output).